### PR TITLE
appsody-source -> git-source

### DIFF
--- a/experimental/java-microprofile-0.2.1/appsody-build-pipeline.yaml
+++ b/experimental/java-microprofile-0.2.1/appsody-build-pipeline.yaml
@@ -4,7 +4,7 @@ metadata:
   name: appsody-build-pipeline
 spec:
   resources:
-    - name: appsody-source
+    - name: git-source
       type: git
     - name: docker-image
       type: image
@@ -14,8 +14,8 @@ spec:
         name: appsody-build-task
       resources:
         inputs:
-        - name: appsody-source
-          resource: appsody-source
+        - name: git-source
+          resource: git-source
         outputs:
         - name: docker-image
           resource: docker-image

--- a/experimental/java-microprofile-0.2.1/appsody-build-task.yaml
+++ b/experimental/java-microprofile-0.2.1/appsody-build-task.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   inputs:
     resources:
-      - name: appsody-source
+      - name: git-source
         type: git
     params:
       - name: pathToDockerFile


### PR DESCRIPTION
tekton-dashboard webhook requires the resource names of 'git-source' and 'docker-image'

https://github.com/tektoncd/experimental/blob/7697ee7cee390338e2468eb4abcc4d9490a49cb9/webhooks-extension/README.md#a-pipelinerun

https://github.com/tektoncd/experimental/blob/master/webhooks-extension/pkg/endpoints/sink.go#L204

otherwise the binding fails

```
 Last Transition Time:  2019-08-02T14:57:38Z
    Message:               PipelineRun kabanero/appsody-build-pipeline-webhook-1564757858 doesn't bind Pipeline kabanero/appsody-build-pipeline's PipelineResources correctly: PipelineRun bound resources didn't match Pipeline: Didn't provide required values: [appsody-source]
```